### PR TITLE
fix: t_i to t_n for consistency

### DIFF
--- a/tex/sections/preliminaries.tex
+++ b/tex/sections/preliminaries.tex
@@ -69,8 +69,8 @@ Stability properties can be achieved by different means, for example by the use 
 When using explicit methods, smaller timesteps may be required to guarantee stability. 
 
 % Timestep controller
-Another important consideration is the choice of the time-steps $\Delta t_i$ in a numerical solver \cite{hairer-solving-1}. 
-Modern solvers include stepsize controllers that pick $\Delta t_i$ as large as possible to minimize the total number of steps while preventing large errors in the numerical solution controlled by adjustable relative and absolute tolerances (see Appendix \ref{appendix:dual-number-solver}). 
+Another important consideration is the choice of the time-steps $\Delta t_n$ in a numerical solver \cite{hairer-solving-1}. 
+Modern solvers include stepsize controllers that pick $\Delta t_n$ as large as possible to minimize the total number of steps while preventing large errors in the numerical solution controlled by adjustable relative and absolute tolerances (see Appendix \ref{appendix:dual-number-solver}). 
 
 % Generalization 
 % It is important to remark that direct methods to solve higher order systems of ODEs exist, including Nystrom methods, but we can usually reduce them to a extended systems of ODEs \cite{hairer-solving-1}. 


### PR DESCRIPTION
If I understand correctly, throughout the text `\Delta t_n` is used throughout, with the exception of the 2 uses of `\Delta t_i` here. Therefore I changed it for consistency. 